### PR TITLE
Fixed name of the variant working in linux

### DIFF
--- a/Dotfiles/keyboard/README.md
+++ b/Dotfiles/keyboard/README.md
@@ -9,5 +9,5 @@ Changing the "Option" key on Mac keyboard for the "Right Alt" on regular keyboar
 If setting up the keyboard layout under .config doesn't work:
 ```
 cp ./us /usr/share/X11/xkb/symbols/us
-setxkbmap -layout us -variant mac
+setxkbmap -layout us -variant altgr-intl
 ```


### PR DESCRIPTION
The variant that actually works with the provided file is the altgr-intl one, at least in linux.
